### PR TITLE
feat: Add Dask cluster with adaptive scaling

### DIFF
--- a/analysis_demo_coffea.ipynb
+++ b/analysis_demo_coffea.ipynb
@@ -300,13 +300,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "coffea version:  2024.6.1\n"
+      "coffea version: 2024.6.1\n"
      ]
     }
    ],
    "source": [
     "import coffea\n",
-    "print(\"coffea version: \",coffea.__version__)\n",
+    "print(f\"coffea version: {coffea.__version__}\")\n",
     "from coffea.nanoevents import NanoEventsFactory, PHYSLITESchema\n",
     "from coffea.analysis_tools import PackedSelection\n",
     "from coffea import dataset_tools\n",
@@ -409,14 +409,35 @@
    "source": [
     "To make the loading lighter, we will use the `filter_name` function, in order to load only the properties needed. Then we will use `coffea`'s `NanoEventsFactory.from_root` to load the file. \n",
     "\n",
-    "This is actually a delayed computation. `coffea` is using `dask` as a backend to construct a delayed task graph representing our analysis. So there is some metadata reading but not actual number crunching until `compute()` is called.\n",
+    "This is actually a delayed computation. `coffea` is using `dask` as a backend to construct a delayed task graph representing our analysis. So there is some metadata reading but not actual number crunching until `compute()` is called."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For this demonstration we can optionally take advantage of the computing resources we have access to through the IRIS-HEP Scalable Systems Laboratory and start a `KubeCluster` Dask cluster to adaptively scale out Dask across multiple workers.\n",
     "\n",
+    "_Hint_: Can click and drag the Dask cluster Jupyter widget to the notebook to establish the `client` with the scheduler address autopopulated.\n",
+    "\n",
+    "```python\n",
+    "from dask.distributed import Client\n",
+    "\n",
+    "client = Client(<scheduler address>)\n",
+    "client\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "_Some warnings will appear as we're still working with `uproot` to correctly interpret all the properties stored in PHYSLITE. We will suppress for now._"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -462,7 +483,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -471,7 +492,7 @@
        "['Electrons', 'EventInfo', 'Muons']"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -482,7 +503,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -515,7 +536,7 @@
        "<ElectronArray [[Electron, ..., Electron], ...] type='50000 * var * electron'>"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -526,7 +547,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -535,7 +556,7 @@
        "['pt', '_eventindex', 'eta', 'phi', 'm', 'charge', 'DFCommonElectronsLHLoose']"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -563,7 +584,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -630,7 +651,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -652,7 +673,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {
     "scrolled": true
    },
@@ -664,7 +685,7 @@
        "<IPython.core.display.Image object>"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -693,7 +714,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {
     "slideshow": {
      "slide_type": null
@@ -766,7 +787,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -815,7 +836,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -868,7 +889,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -901,15 +922,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 55.3 s, sys: 4.12 s, total: 59.5 s\n",
-      "Wall time: 53.6 s\n"
+      "CPU times: user 176 ms, sys: 1.36 ms, total: 178 ms\n",
+      "Wall time: 5.44 s\n"
      ]
     }
    ],
@@ -933,7 +954,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -943,7 +964,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {


### PR DESCRIPTION
To demonstrate that scaling can really matter, using a KubeCluster with adaptive scaling and 200 workers minimum drops the time to about 5 seconds.

![new-dask-cluster](https://github.com/ekourlit/scipy2024-ATLAS-demo/assets/5142394/4ac1dac5-8a0e-4b7b-a252-fd0290c7f38f)

![rescale-dask-cluster](https://github.com/ekourlit/scipy2024-ATLAS-demo/assets/5142394/359d8ae7-5b59-4773-bf0e-98d97dfc154a)

![scale-min-workers](https://github.com/ekourlit/scipy2024-ATLAS-demo/assets/5142394/f1cc5d67-8ebe-43ec-a5e3-fa1c16af4029)

![image](https://github.com/ekourlit/scipy2024-ATLAS-demo/assets/5142394/0de467da-deb9-470f-8a0f-950d2f458490)



```diff
-      "CPU times: user 55.3 s, sys: 4.12 s, total: 59.5 s\n",
-      "Wall time: 53.6 s\n"
+      "CPU times: user 176 ms, sys: 1.36 ms, total: 178 ms\n",
+      "Wall time: 5.44 s\n"
```